### PR TITLE
Fix captcha and box-shadow

### DIFF
--- a/app/assets/stylesheets/colors.css.scss
+++ b/app/assets/stylesheets/colors.css.scss
@@ -7,7 +7,7 @@ $background-blue: #E7F2F7;
 $grey: #2B2B2B;
 $light-grey: #DDDDDD;
 
-$border-grey: #CCCCCC;
+$border-grey: #DDDDDD;
 $border-dark-grey: #999999;
 
 $link-grey: #777777;

--- a/app/assets/stylesheets/new_styles/_forms.scss
+++ b/app/assets/stylesheets/new_styles/_forms.scss
@@ -1,19 +1,19 @@
 input,
+input[type=email],
+input[type=text],
+input[type=password],
 textarea { /* Bootstrap reset */
   &,
   &:active,
   &:invalid,
-  &:invalid:required, {
-    border-color: $border-grey;
-    box-shadow: none;
-  }
-
+  &:invalid:required,
   &:focus,
   &:active:focus,
   &:invalid:focus,
   &:invalid:required:focus {
-    border-color: $border-dark-grey;
+    border-color: $border-grey;
     box-shadow: none;
+    color : $text-dark-grey;
   }
 }
 
@@ -78,19 +78,6 @@ form.block-form {
       }
     }
 
-    .form-control:focus {
-      &,
-      &:invalid,
-      &:invalid:required {
-        border-color: $border-dark-grey;
-        border-bottom-width: 1px;
-      }
-      /* remove the border of the element under the one with the focus */
-      & + label + .entypo + .form-control {
-        border-top-width: 0px;
-      }
-    }
-
     .entypo {
       position: absolute;
       top: 10px;
@@ -113,7 +100,7 @@ form.block-form {
       top: 130px;
     }
 
-    input:-moz-placeholder { text-transform: uppercase; }
+    input::-moz-placeholder { text-transform: uppercase; }
     input::-webkit-input-placeholder { text-transform: uppercase; }
     input:-ms-input-placeholder { text-transform: uppercase; }
   }

--- a/app/assets/stylesheets/new_styles/_registration.scss
+++ b/app/assets/stylesheets/new_styles/_registration.scss
@@ -32,39 +32,25 @@
   }
 
   form {
-    .form-control:last-of-type {
-      border-bottom-left-radius: 0px;
-      border-bottom-right-radius: 0px;
+    max-width: 400px;
+
+    .captcha_img {
+      position: absolute;
+      left: 10px;
+      width: 120px;
+      top: 169px;
     }
 
-    .captcha {
-      border: 1px solid $border-grey;
-      border-top: 0px;
+    #user_captcha {
+      font-size: 16px;
+      height: 40px;
+      padding: 10px 10px 10px 130px;
+      line-height: 20px;
+      box-sizing: border-box;
+      width: 100%;
+      border-bottom: 1px solid $border-grey;
       border-bottom-left-radius: 5px;
       border-bottom-right-radius: 5px;
-
-      .captcha_img {
-        float: left;
-        margin-top: 3px;
-      }
-
-      #user_captcha {
-        float: right;
-        width: 69%;
-        border: 0px;
-        border-radius: 0px;
-        border-bottom-right-radius: 5px;
-        border-left: 1px solid $border-grey;
-
-        &:focus {
-          border: solid 1px $border-dark-grey;
-          /* Sorry about this dirty hack, the only way I found to correctly display the grey border */
-          position: relative;
-          top: -1px;
-          margin-right: -1px;
-          margin-bottom: -2px;
-        }
-      }
     }
 
     #terms > a {

--- a/app/views/registrations/new.haml
+++ b/app/views/registrations/new.haml
@@ -8,7 +8,7 @@
           %h3#diaspora-hearts
             = t('.diaspora')
         .span5
-          .pull-right
+          .text-center
             %h2#pod-name
               = AppConfig.settings.pod_name
             = form_for(resource, url: registration_path(resource_name), html: {class: "form-horizontal block-form", autocomplete: "off"}) do |f|
@@ -34,9 +34,7 @@
                 = f.password_field :password_confirmation, class: "input-block-level form-control", placeholder: t('.password_confirmation'), title: t('registrations.new.enter_password_again'), required: true, pattern: "......+"
 
                 - if AppConfig.settings.captcha.enable?
-                  .captcha
-                    = show_simple_captcha(object: 'user', code_type: 'numeric')
-                    %div{style: "clear:both;"}
+                  = show_simple_captcha :object => 'user', :code_type => 'numeric'
 
                 = invite_hidden_tag(invite)
 


### PR DESCRIPTION
Alright, I think I fixed most issues. I reverted the changes for `$border-grey` ([comment](https://github.com/diaspora/diaspora/pull/5391#discussion_r22863184)), fixed the box-shadow and input color and fixed the captcha. I had to remove the dark border for active inputs so the border doesn't change anymore.

This is the registration form with a captcha:
![](https://cloud.githubusercontent.com/assets/3798614/6191275/6fd37a1e-b3a8-11e4-8cda-bc6dd45e0e53.png)
and without a captcha:
![](https://cloud.githubusercontent.com/assets/3798614/6191282/7d9b8010-b3a8-11e4-84b7-c8353d7e0421.png)