### PR TITLE
Log signatures read/write for relayables

### DIFF
--- a/lib/diaspora/relayable.rb
+++ b/lib/diaspora/relayable.rb
@@ -23,8 +23,31 @@ module Diaspora
         after_commit :on => :create do
           parent.touch(:interacted_at) if parent.respond_to?(:interacted_at)
         end
-
       end
+    end
+
+    def author_signature
+      logger.debug("# SGN_DBG ↳ #{__method__}\n     from " + caller[0..20].join("\n     from "))
+
+      super
+    end
+
+    def parent_author_signature
+      logger.debug("# SGN_DBG ↳ #{__method__}\n     from " + caller[0..20].join("\n     from "))
+
+      super
+    end
+
+    def author_signature=(*args)
+      logger.debug("# SGN_DBG ↳ #{__method__}\n     from " + caller[0..20].join("\n     from "))
+
+      super
+    end
+
+    def parent_author_signature=(*args)
+      logger.debug("# SGN_DBG ↳ #{__method__}\n     from " + caller[0..20].join("\n     from "))
+
+      super
     end
 
     def author_is_not_ignored


### PR DESCRIPTION
This adds the logging of all the read/write accesses to the ```author_signature``` and ```parent_author_signature``` of any relayable.

I propose to run a production pod with this patch and gather some real world information.

Study of the resulting logs will allow us to find out whether this signatures are used anywhere (except of obvious and known cases) and so to know if we could safely remove them in order to close #4920.